### PR TITLE
feat: Apply modern UI styling

### DIFF
--- a/UI/Views/LayerManagerWindow.xaml
+++ b/UI/Views/LayerManagerWindow.xaml
@@ -10,8 +10,29 @@
         MinHeight="400" MinWidth="350">
 
     <Window.Resources>
-        <!-- Этот ресурс был добавлен для исправления ошибки XamlParseException -->
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <Style TargetType="Button">
+            <Setter Property="Padding" Value="10,5"/>
+            <Setter Property="Margin" Value="4,0"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="4">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#E0E0E0"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
     </Window.Resources>
 
     <!-- ViewModel is created in code-behind, we only specify the data type here -->
@@ -19,14 +40,14 @@
         <vm:LayerManagerViewModel/>
     </Window.DataContext>
 
-    <Grid Margin="10">
+    <Grid Margin="15">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <TextBox Grid.Row="0" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10" />
+        <TextBox Grid.Row="0" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,15" />
 
         <!-- Layer List -->
         <ListView Grid.Row="1"
@@ -36,8 +57,7 @@
                   SelectionMode="Extended"
                   SelectionChanged="LayersListView_SelectionChanged"
                   AlternationCount="2"
-                  BorderThickness="1"
-                  BorderBrush="LightGray">
+                  BorderThickness="0">
             <ListView.View>
                 <GridView>
                     <GridViewColumn Header="Current" Width="60">
@@ -120,19 +140,15 @@
         </ListView>
 
         <!-- Button Panel -->
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,15,0,0">
             <Button Content="Set Current" 
-                    Command="{Binding SetCurrentCommand}" 
-                    Width="100" Margin="5"/>
+                    Command="{Binding SetCurrentCommand}"/>
             <Button Content="Change Color" 
-                    Command="{Binding ChangeColorCommand}" 
-                    Width="100" Margin="5"/>
+                    Command="{Binding ChangeColorCommand}"/>
             <Button Content="Select by Color"
-                    Command="{Binding SelectByColorCommand}"
-                    Width="100" Margin="5"/>
+                    Command="{Binding SelectByColorCommand}"/>
             <Button Content="Refresh" 
-                    Command="{Binding RefreshCommand}" 
-                    Width="80" Margin="5"/>
+                    Command="{Binding RefreshCommand}"/>
         </StackPanel>
     </Grid>
 </Window>


### PR DESCRIPTION
Refreshes the UI to give it a more modern look, similar to WinUI 3.

- Adds a default Style for Buttons with rounded corners and improved padding.
- Removes the border from the main ListView for a softer, cleaner look.
- Adjusts margins and spacing throughout the window for a less cluttered layout.
- This commit includes all previously developed features (search, rename, group ops, select by color) with the new styling applied.